### PR TITLE
refactor: do not download all sample dataset from sra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ figures_gabaritos
 **/data/
 **/__pycache__/**
 import_paths.txt
+.vscode/

--- a/data/populus/download_sub.sh
+++ b/data/populus/download_sub.sh
@@ -1,5 +1,4 @@
 for i in SRR6249795 SRR6249808 SRR6249768 SRR6249769 SRR6249770 SRR6249771 SRR6249772 SRR6249773 SRR6249774 SRR6249775 SRR6249776 SRR6249778 SRR6249779 SRR6249780 SRR6249781 SRR6249782 SRR6249783 SRR6249784 SRR6249785 SRR6249786 SRR6249787 SRR6249788; do
     echo $i
-    docker run -v $(pwd):/opt/ cristaniguti/sratoolkit ./fasterq-dump $i -O /opt/
-    head -n 1200000 $i.fastq > $i.sub.fastq # Just a subset of the reads
+    echo docker run -v $(pwd):/opt/ --rm --entrypoint /usr/bin/fastq-dump -w /opt/ cyverseuk/fastq-dump:latest -X 300000 --gzip $i
 done


### PR DESCRIPTION
With `fastq-dump` parameter `-X` you can download only first spots in the dataset, speeding up de process.